### PR TITLE
Remapping mingw

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -351,7 +351,7 @@ def configure(env):
 		env.Append(CCFLAGS=['-DWINDOWS_ENABLED','-mwindows'])
 		env.Append(CPPFLAGS=['-DRTAUDIO_ENABLED'])
 		env.Append(CCFLAGS=['-DGLES2_ENABLED','-DGLEW_ENABLED'])
-		env.Append(LIBS=['mingw32','opengl32', 'dsound', 'ole32', 'd3d9','winmm','gdi32','iphlpapi','shlwapi','wsock32','kernel32', 'oleaut32', 'dinput8', 'dxguid', 'XINPUT_9_1_0'])
+		env.Append(LIBS=['mingw32','opengl32', 'dsound', 'ole32', 'd3d9','winmm','gdi32','iphlpapi','shlwapi','wsock32','kernel32', 'oleaut32', 'dinput8', 'dxguid', 'xinput'])
 
 		# if (env["bits"]=="32"):
 # #			env.Append(LIBS=['gcc_s'])

--- a/platform/windows/joystick.cpp
+++ b/platform/windows/joystick.cpp
@@ -476,8 +476,17 @@ unsigned int joystick_windows::process_joysticks(unsigned int p_last_id) {
 		int values[] = { js.lX, js.lY, js.lZ, js.lRx, js.lRy, js.lRz };
 
 		for (int j = 0; j < joy->joy_axis.size(); j++) {
-			// Is this right? I can't tell. If it is, it could replace the switch
-			p_last_id = input->joy_axis(p_last_id, i, j, axis_correct(values[joy->joy_axis[j] - DIJOFS_X]));
+			// Can't do this, axis numbers aren't sequential
+			// They're 0, 4, 8, 12, ... but I don't know if we can assume that's the case in every windows with every joystick. If yes, feel free to change
+			// p_last_id = input->joy_axis(p_last_id, i, j, axis_correct(values[joy->joy_axis[j] - DIJOFS_X])); // can't do this, axis numbers aren't sequential
+
+			// intead, a for
+			for (int k=0; k<count; k++) {
+				if (joy->joy_axis[j] == axes[k]) {
+					p_last_id = input->joy_axis(p_last_id, i, j, axis_correct(values[k]));
+					break;
+				};
+			};
 		};
 
 #else

--- a/platform/windows/joystick.h
+++ b/platform/windows/joystick.h
@@ -33,7 +33,7 @@
 #include "os_windows.h"
 #define DIRECTINPUT_VERSION 0x0800
 #include <dinput.h>
-#include <Xinput.h>
+#include <xinput.h> // on unix the file is called "xinput.h", on windows I'm sure it won't mind
 
 #ifndef SAFE_RELEASE            // when Windows Media Device M? is not present
 #define SAFE_RELEASE(x) \

--- a/platform/x11/joystick_linux.cpp
+++ b/platform/x11/joystick_linux.cpp
@@ -272,7 +272,7 @@ void joystick_linux::open_joystick(const char *p_path) {
         //check if the device supports basic gamepad events, prevents certain keyboards from
         //being detected as joysticks
         if (libevdev_has_event_type(dev, EV_ABS) && libevdev_has_event_type(dev, EV_KEY) &&
-                (libevdev_has_event_code(dev, EV_KEY, BTN_SOUTH) || libevdev_has_event_code(dev, EV_KEY, BTN_THUMBL) || libevdev_has_event_code(dev, EV_KEY, BTN_TOP))) {
+                (libevdev_has_event_code(dev, EV_KEY, BTN_A) || libevdev_has_event_code(dev, EV_KEY, BTN_THUMBL) || libevdev_has_event_code(dev, EV_KEY, BTN_TOP))) {
 
             char uid[128];
             String name = libevdev_get_name(dev);


### PR DESCRIPTION
Made some changes to test on my linux and windows computers, and to build with mingw. This is awesome, thanks for the work, we're really looking forward to this feature. There's 3 issues remaining:
- We use tabs instead of spaces to indent :)
- On Windows, the trigger buttons (at least on a PS4 pad) still report the axis value as -1..1, we need to take the range from the hardware, or figure out when to send "true" for the trigger parameter to axis_correct()?
- The biggest one is that it depends on some xinput dll, is it possible to static link it, or not use it alltogether? From what I see in the code, some joysticks are "dinput", some are "xinput"? What's the advantage of xinput?  It looks like the events are sent twice, one for each method, but I'm not familiar with the code. Can we avoid using it, or turn it off with a #define ? At least for the editor, which is distributed as a single .exe, we'd like to avoid having to pack dlls with it.

There's also a few changes to get it to build on mingw, I put comments in the code, I'm not sure if I'm using the right version of stuff. We use mingw to do the automated builds on our server, so it needs to work there..

Thanks.
